### PR TITLE
Add signature and certificate generation functionality

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -7,7 +7,7 @@ from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse, Response
 from fastapi.middleware.cors import CORSMiddleware
 
-
+from py_cc.cc import gen_compact_certificate
 from app import db
 from app import utils
 from app.models import (
@@ -70,53 +70,37 @@ async def startup_event():
 
 @app.post("/api/genProof")
 async def genproof(request: GenProofRequest):
-    command = (
-        "python3 main.py -n "
-        + str(request.count)
-        + " -m "
-        + str(request.message)
+    message = db.messages[request.message]
+    signed_attestors = {}
+    for validator, signature in message.signed_validators.items():
+        attestor = db.get_attestor(validator.wallet_address)
+        sig_cc = db.get_signature_cc(message.message, validator)
+        signed_attestors[attestor] = sig_cc
+    gen_compact_certificate(
+        message=message.message,
+        attestors=list(db.attestors.values()),
+        signed_attestors=signed_attestors,
     )
-    result = subprocess.run(command, shell=True, capture_output=True)
-    genCertTime = result.stdout.decode("utf-8").strip().split(" ")[-1]
 
     # generate zkproof
     command_zoc = "cd zokratesjs && node index.js && cd .."
-    zoc_result = subprocess.run(
-        command_zoc,
-        shell=True,
-        capture_output=True).stdout.decode('utf-8')
-    compileZokTime, computeTime, verifyTime, _ = [s.strip().split(
-        " ")[-1] for s in zoc_result.split('\n')]
-
-    # with open("certificate.json") as f:
-    #     certificate = json.load(f)
+    try:
+        subprocess.run(
+            command_zoc,
+            shell=True,
+            capture_output=True).stdout.decode('utf-8')
+    except subprocess.CalledProcessError as e:
+        return Response(status_code=500, content=e.stderr)
 
     with open("./zokratesjs/proof.json") as f:
         proof = json.load(f)
-
-    # with open("attest.txt") as f:
-    #     lines = f.read().splitlines()
-    #     validators = []
-    #     for count, line in enumerate(lines):
-    #         if count < int(request.count):
-    #             public_key, weight = line.split(",")
-    #             validators.append({"public_key": public_key, "weight": weight})
-
-    # data = GenProofResponse(**{
-    #     "certificate": certificate,
-    #     "proof": proof,
-    #     "validators": validators,
-    #     "genCertTime": genCertTime + " sec",
-    #     "compileZokTime": compileZokTime,
-    #     "computeTime": computeTime,
-    #     "verifyTime": verifyTime
-    # })
 
     return JSONResponse(content=proof)
 
 
 @app.post("/api/signMessage")
 async def sign_message(request: SignMessageRequest):
+    validator = db.get_validators(request.wallet_address)
     attestor = db.get_attestor(request.wallet_address)
     validator = db.get_validators(request.wallet_address)
 
@@ -184,59 +168,3 @@ async def get_messages() -> List[dict]:
 async def save_message(request: SaveMessageRequest):
     db.save_message(message=request.message,
                     wallet_address=request.wallet_address)
-
-
-# @app.post("/upload")
-# async def upload(request: Request):
-#     input_data = await request.json()
-#     input_count = input_data["inputCount"]
-#     input_message = input_data["inputMessage"]
-#     print(input_count, input_message)
-
-#     run_command = (
-#         "python3 main.py -n "
-#         + str(input_count)
-#         + " -m "
-#         + str(input_message)
-#     )
-#     print(run_command)
-#     result = subprocess.run(run_command, shell=True, capture_output=True)
-#     print(result)
-#     genCertTime = result.stdout.decode("utf-8").strip().split(" ")[-1]
-
-#     # generate zkproof
-#     run_command_zoc = "cd zokratesjs && node index.js && cd .."
-
-#     zoc_result = subprocess.run(
-#         run_command_zoc,
-#         shell=True,
-#         capture_output=True).stdout.decode('utf-8')
-#     compileZokTime, computeTime, verifyTime, _ = [s.strip().split(
-#         " ")[-1] for s in zoc_result.split('\n')]
-
-#     print(compileZokTime, computeTime, verifyTime)
-
-#     with open("certificate.json") as f:
-#         data1 = json.load(f)
-
-#     with open("./zokratesjs/proof.json") as f:
-#         data2 = json.load(f)
-
-#     with open("attest.txt") as f:
-#         lines = f.read().splitlines()
-#         data3 = []
-#         for count, line in enumerate(lines):
-#             if count < int(input_count):
-#                 public_key, weight = line.split(",")
-#                 data3.append({"public_key": public_key, "weight": weight})
-#     data = {
-#         "data1": data1,
-#         "data2": data2,
-#         "data3": data3,
-#         "genCertTime": genCertTime + " sec",
-#         "compileZokTime": f"Compile Zokrates: {compileZokTime} sec",
-#         "computeTime": f"Compute Witness & Generate Proof: {computeTime} sec",
-#         "verifyTime": f"Verify Proof: {verifyTime} sec"
-#     }
-
-#     return JSONResponse(content=data)

--- a/app/models.py
+++ b/app/models.py
@@ -19,7 +19,6 @@ class SaveMessageRequest(BaseModel):
 
 
 class GenProofRequest(BaseModel):
-    count: int
     message: str
 
 

--- a/py_cc/cc.py
+++ b/py_cc/cc.py
@@ -1,0 +1,59 @@
+import json
+from typing import List
+
+from py_cc.certificate import Attestor, CompactCertificate, Certificate
+from py_cc.elliptic_curves.baby_jubjub import curve
+from py_cc.hashes import (
+    Poseidon, prime_254, matrix_254_3,
+    round_constants_254_3
+)
+
+
+def gen_compact_certificate(
+    message: str,
+    attestors: List[Attestor],
+    signed_attestors: dict  # Dict[Attestor, Signature]
+):
+    hash = Poseidon(
+        prime_254,
+        128,
+        5,
+        3,
+        full_round=8,
+        partial_round=57,
+        mds_matrix=matrix_254_3,
+        rc_list=round_constants_254_3,
+    )
+    Cc = CompactCertificate(message, hash, curve, len(attestors))
+    Cc.setAttestors(attestors)
+    Cc.setSignatures(signed_attestors)
+    print(f"buildMerkleTree for message {message}")
+    Cc.buildAttesterTree()
+    Cc.buildSignTree()
+
+    print("createMap")
+    Cc.createMap()
+
+    print("getCertificate")
+    attester_root, message, proven_weight, cert, coins = Cc.getCertificate()
+
+    # we save the certificate into a json file then pass to Zokrates to generate proof
+    print(f"Certificate JSON for message {message}")
+    test = Certificate(message, "PoseidonHash", "BabyJubjub", "EdDSA", cert)
+    cert_json = test.toJSON()
+    verify_json = [
+        {
+            "message": f"0x{hash.run(message).hexdigest()}",
+        },
+        {
+            "attester_root": f"0x{attester_root}",
+            "proven_weight": f"{proven_weight}",
+        },
+        cert_json["certificate"],
+        coins,
+    ]
+    with open("zokratesjs/verify.json", "w") as file:
+        json.dump(verify_json, file, indent=4)
+
+    with open("zokrates/verify.json", "w") as file:
+        json.dump(verify_json, file, indent=4)

--- a/test/app/test_app.py
+++ b/test/app/test_app.py
@@ -103,11 +103,16 @@ def test_signIn():
 
 
 def test_genProof():
+    mm = None
+    for m in messages.values():
+        if m.signed_validators:
+            mm = m
+            break
+
     response = client.post(
         "/api/genProof",
         json={
-            "count": 2,
-            "message": message.message
+            "message": mm.message
         }
     )
     assert response.status_code == 200


### PR DESCRIPTION
This pull request adds the ability to generate signatures and certificates for messages in the system. Specifically, it includes the following commits:



* store signature cc

* gen_compact_certificate

* remove count in genProofRequest

* Add __hash__ method to Attestor class



The `store signature cc` commit adds the ability to store signatures for messages in the system. The `gen_compact_certificate` commit adds the ability to generate compact certificates for messages using the Py-CC library. The `remove count in genProofRequest` commit removes an unnecessary count parameter from the `genProofRequest` endpoint. Finally, the `Add __hash__ method to Attestor class` commit adds a `__hash__` method to the `Attestor` class to enable it to be used as a key in dictionaries.